### PR TITLE
Changed GET parameters to path parameters.

### DIFF
--- a/backend/rest.py
+++ b/backend/rest.py
@@ -22,103 +22,74 @@ db = {'TODO': 'Replace with DB query'}
 
 ### Internal ID lookup for any resource
 
-id_parser = api.parser()
-id_parser.add_argument('id', type=int, required=True)
-
-@api.route('/id')
+@api.route('/id/<int:id>')
 class ID_Res(Resource):
 
-    @api.expect(id_parser)
-    def get(self):
-        args = id_parser.parse_args()
-        return {'message': db['TODO']}
+    def get(self, id):
+        return {'message': db.get(id, id)}
 
 
-### Player lookup by name or id number. Name returns first with that name since not unique?
+### Player lookup by id number
 
-player_parser = api.parser()
-player_parser.add_argument('name', type=str)
-player_parser.add_argument('id', type=int)
+@api.route('/player_id/<int:id>')
+class Player_ID(Resource):
 
-@api.route('/player')
-class Player_Res(Resource):
+    def get(self, id):
+        return {'message': db.get(id, id)}
 
-    @api.expect(player_parser)
-    def get(self):
-        args = player_parser.parse_args()
-        if args['name'] is None and args['id'] is None:
-            abort(400, 'At least one of player id or name is required. Player id is preferred.')
-        return {'message': str(args)}
+
+### Player lookup by name
+
+@api.route('/player_name/<string:name>')
+class Player_Name(Resource):
+
+    def get(self, name):
+        return {'message': db.get(name, name)}
 
 
 ### DLC Lookup by name
 
-dlc_parser = api.parser()
-dlc_parser.add_argument('name', type=str, required=True)
-
-@api.route('/dlc')
+@api.route('/dlc/<string:name>')
 class DLC_Res(Resource):
 
-    @api.expect(dlc_parser)
-    def get(self):
-        args = dlc_parser.parse_args()
-        return {'message': db['TODO']}
+    def get(self, name):
+        return {'message': db.get(name, name)}
 
 
 ### Body lookup by name
 
-body_parser = api.parser()
-body_parser.add_argument('name', type=str, required=True)
-
-@api.route('/body')
+@api.route('/body/<string:name>')
 class Body_Res(Resource):
 
-    @api.expect(body_parser)
-    def get(self):
-        args = body_parser.parse_args()
-        return {'message': db['TODO']}
+    def get(self, name):
+        return {'message': db.get(name, name)}
 
 
 ### Crate lookup by name
 
-crate_parser = api.parser()
-crate_parser.add_argument('name', type=str, required=True)
-
-@api.route('/crate')
+@api.route('/crate/<string:name>')
 class Crate_Res(Resource):
 
-    @api.expect(crate_parser)
-    def get(self):
-        args = crate_parser.parse_args()
-        return {'message': db['TODO']}
+    def get(self, name):
+        return {'message': db.get(name, name)}
 
 
 ### Antenna lookup by name
 
-antenna_parser = api.parser()
-antenna_parser.add_argument('name', type=str, required=True)
+@api.route('/paint/<string:name>')
+class Paint_Res(Resource):
 
-@api.route('/antenna')
-class Antenna_Res(Resource):
-
-    @api.expect(antenna_parser)
-    def get(self):
-        args = antenna_parser.parse_args()
-        return {'message': db['TODO']}
+    def get(self, name):
+        return {'message': db.get(name, name)}
 
 
 ### Decal lookup by name
 
-decal_parser = api.parser()
-decal_parser.add_argument('name', type=str, required=True)
-
-@api.route('/decal')
+@api.route('/decal/<string:name>')
 class Decal_Res(Resource):
 
-    @api.expect(decal_parser)
-    def get(self):
-        args = decal_parser.parse_args()
-        return {'message': db['TODO']}
+    def get(self, name):
+        return {'message': db.get(name, name)}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changed parameters from 'optional' arguments to path parameters, to make documentation easier and reduce code. Additionally, required arguments are typically part of the uri so that forgetting them results in a 404. Apiary assumes that true arguments (those after a ?) are optional.