### PR TITLE
Made meta return all details on the object in a list

### DIFF
--- a/backend/rest.py
+++ b/backend/rest.py
@@ -109,7 +109,7 @@ class Decal_Res(Resource):
 
 def get_mapping(Class):
     s = Session()
-    return {r.id: r.name for r in s.query(Class)}
+    return [serialize(r) for r in s.query(Class)]
 
 @api.route('/meta/rarities')
 class GetRarities(Resource):


### PR DESCRIPTION
/api/meta/crates now returns
`[{"retire_date": null, "items": null, "id": 6991, "source": null, "name": "Turbo Crate", "description": "The Turbo Crate was released on March 22, 2017, as part of the Dropshot update. It is the first crate to feature a Battle-Car not directly referencing an existing design.", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/6/62/Turbo_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170905192324", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 7237, "source": null, "name": "Overdrive Crate", "description": "The Overdrive Crate was released on July 5, 2017, as part of the second anniversary Champions Field update. It is the third crate to feature a Battle-Car not directly based on an existing design.", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/b/be/Overdrive_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170905191459", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 8313, "source": null, "name": "Accelerator Crate", "description": "The Accelerator Crate is a crate released on September 28, 2017, as part of the Autumn Update. There is a chance of obtaining one of the following items when unlocking this crate: 1 Rare paint finish, 4 Rare decals, 2 Very Rare trails, 1 Very Rare wheels, 1 Very Rare decal, 1 Import body, 1 Import rocket boost, 1 Import wheels, 2 Exotic wheels, 4 Black Market goal explosions", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/7/7a/Accelerator_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170913172521", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 6987, "source": null, "name": "Champion Crate 1", "description": "Champion Crate 1 is a crate that was released on September 8, 2016, alongside Champion Crate 2. There is a chance of obtaining one of the following items when unlocking this crate: 5 Rare decals, 3 Very Rare decals, 1 Very Rare wheels, 1 Import rocket boost, 2 Import bodies, 2 Exotic wheels", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/e/e8/Champion_1_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170905231635", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 6983, "source": null, "name": "Nitro Crate", "description": "The Nitro Crate was released on May 10, 2017, as part of the Neo Tokyo/Tokyo Underpass update. It is the second crate to feature a Battle-Car not directly based on an existing design.", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/b/b8/Nitro_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170905222023", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 6988, "source": null, "name": "Player's Choice Crate", "description": "The Player's Choice Crate was released on February 21, 2017. Although the Rocket League website refers to this crate as \"Series 1\", no other Player's Choice Crates have been announced as of September 9, 2017.", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/6/6c/Player%27s_Choice_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170909171506", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 6990, "source": null, "name": "Champion Crate 2", "description": "Champion Crate 2 was released on September 8, 2016, alongside Champion Crate 1. This crate contains the following items: 5 Very Rare decals, 3 Rare decals, 2 Import bodies, 2 Exotic wheels, 1 Import rocket trail, 1 Very Rare rocket trail", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/6/64/ChampionCrate2.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20161202034413", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 6992, "source": null, "name": "Champion Crate 3", "description": "Champion Crate 3 was released on October 4, 2016, as part of the AquaDome update. This crate contains the following items: 5 Rare decals, 3 Very Rare decals, 2 Import rocket trails, 2 Exotic wheels, 1 Very Rare Wheel, 1 Import body", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/a/a5/ChampionCrate3.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20161202034424", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 6994, "source": null, "name": "Champion Crate 4", "description": "Champion Crate 4 was released on December 7, 2016, as part of the Starbase ARC update. There is a chance of obtaining one of the following items when unlocking this crate: 5 Rare decals, 3 Very Rare decals, 2 Exotic wheels, 1 Import wheel, 1 Very Rare wheel, 1 Import body, 1 Import rocket boost, 2 Black Market decals", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/f/f7/Champion_4_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20170905231755", "rarity": null, "release_date": null}, {"retire_date": null, "items": null, "id": 8696, "source": null, "name": "Haunted Hallows Crate", "description": "The Haunted Hallows Crate is a special event crate released on October 16, 2017. It can be unlocked using both keys and decryptors, and is also available for purchase, either with real money (in the same way as keys) or by using \"Candy Corn\", a new in-game currency available for a limited time. 50 are required for one crate.", "type": "crate", "image": "https://vignette.wikia.nocookie.net/rocketleague/images/6/63/Haunted_Hallows_crate_icon.png/revision/latest/window-crop/width/200/x-offset/0/y-offset/0/window-width/257/window-height/256?cb=20171014133620", "rarity": null, "release_date": null}]`