### PR TITLE
Added searching to rest api

### DIFF
--- a/backend/config/requirements.txt
+++ b/backend/config/requirements.txt
@@ -3,4 +3,5 @@ flask-restplus==0.10.1
 gunicorn==19.7.1
 SQLAlchemy==1.2.0b3
 psycopg2==2.7.3.1
+SQLAlchemy-Searchable==0.10.6
 requests==2.18.4

--- a/backend/data_collection/load_constants.py
+++ b/backend/data_collection/load_constants.py
@@ -1,11 +1,12 @@
 from models import *
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, configure_mappers
 
 
 '''
 This file provides supplemental Rarity values for the RL Objects.
 '''
+configure_mappers()
 
 Base.metadata.reflect(db)
 Base.metadata.drop_all(db)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,11 +1,14 @@
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy import Column, Integer, String, Date, Boolean, ForeignKey, create_engine, Table
-from sqlalchemy.orm import sessionmaker, relationship
-from sqlalchemy.sql import select
+from sqlalchemy import Column, Integer, String, Date, Boolean, ForeignKey, create_engine, Table, UnicodeText
+from sqlalchemy.orm import sessionmaker, relationship, configure_mappers
+from sqlalchemy_searchable import make_searchable
+from sqlalchemy_utils.types import TSVectorType
 import json
 import os
 
 Base = declarative_base()
+
+make_searchable()
 
 DB_NAME = os.environ['DB_NAME']
 DB_USER = os.environ['DB_USER']
@@ -18,21 +21,28 @@ DB_HOST = os.environ['DB_HOST']
 # if it already exists)
 
 db = create_engine('{dialect}://{user}:{password}@{host}/{db}'.format(dialect=DB_DIALECT, user=DB_USER, password=DB_PASS, host=DB_HOST, db=DB_NAME))
-Session = sessionmaker(bind=db)
+_session_maker = None
+
+# Defined this way so configuration isn't loaded until a Session is requested
+def Session():
+    global _session_maker
+    if not _session_maker:
+        _session_maker = sessionmaker(bind=db)
+    return _session_maker()
 
 class DBObject: # Everything
     id = Column(Integer, primary_key=True)
-    name = Column(String(50))
+    name = Column(UnicodeText)
 
 class RLObject(Base, DBObject): # Non-meta
     __tablename__ = 'objects'
 
     id = Column(Integer, primary_key=True)
 
-    type = Column('type', String(50))
+    type = Column('type', UnicodeText)
     __mapper_args__ = {'polymorphic_on': type}
 
-    image = Column(String(300)) # URL of image
+    image = Column(String) # URL of image
 
     def __eq__(self, other):
         return serialize_str(self) == serialize_str(other)
@@ -43,7 +53,8 @@ class RLObject(Base, DBObject): # Non-meta
 
 class RLObtainable(RLObject): # Not Players
     release_date = Column(Date)
-    description = Column(String)
+    description = Column(UnicodeText)
+    search_vector = Column(TSVectorType('name', 'description', 'type'))
 
 class RLItem(RLObtainable): # Not DLC
     @declared_attr
@@ -172,6 +183,8 @@ def serialize(rl_object):
         return None
     sdict = {k: rl_object.__dict__[k] for k in rl_object.__dict__ if not k.startswith('_')}
     sdict['type'] = CLASS_TO_TYPE.get(type(rl_object))
+    if 'search_vector' in sdict:
+        del sdict['search_vector']
     for rel in RELATION_KEYS.get(type(rl_object), []):
         sdict[rel] = list(k.id for k in getattr(rl_object, rel))
     return sdict

--- a/backend/rest.py
+++ b/backend/rest.py
@@ -3,6 +3,7 @@ from flask_restplus import Api, Resource, reqparse, abort
 from werkzeug.contrib.fixers import ProxyFix
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy_searchable import search
 from werkzeug.exceptions import BadRequest, NotFound
 from models import *
 import about_stats
@@ -144,6 +145,15 @@ class Decal_Res(Resource):
         if name.isdigit():
             return get_obj_by_id(Decal, int(name))
         return get_obj_by_name(Decal, name)
+
+
+### Search
+
+@api.route('/search/<string:term>')
+class Search_Res(Resource):
+
+    def get(self, term):
+        return [serialize(k) for k in search(Session().query(RLObtainable), term, sort=True)]
 
 
 ### Meta mappings


### PR DESCRIPTION
This uses SQLAlchemy-Searchable, an extension to sqlalchemy that indexes chosen columns for searching. This isn't perfect yet; it only searches items (not players); and the search term is directly passed to the engine. This causes some problems, like searching a substring might not return the desired results. I will probably keep looking at other searching options, but this works well enough for now.