### PR TITLE
Added custom search function and changed default search endpoint.

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,3 +1,4 @@
+from heapq import heappush, heappop
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy import Column, Integer, String, Date, Boolean, ForeignKey, create_engine, Table, UnicodeText
 from sqlalchemy.orm import sessionmaker, relationship, configure_mappers
@@ -48,13 +49,16 @@ class RLObject(Base, DBObject): # Non-meta
     @declared_attr
     def platform(cls):
         return Column(Integer, ForeignKey('platforms.id'))
+
     def __eq__(self, other):
         return serialize_str(self) == serialize_str(other)
+
+    def __lt__(self, other):
+        return self.name < other.name
 
     def __repr__(self):
         return "<RLObject(id='{0}', name='{1}', type='{2}')>".format(
                                 self.id, self.name, CLASS_TO_TYPE.get(type(self)))
-    
 
 class RLObtainable(RLObject): # Not Players
     release_date = Column(Date)
@@ -265,3 +269,25 @@ def deserialize_list(json_str):
     object_list = [_deserialize_helper(json) for json in json_list]
     return object_list
 
+def search(class_, term):
+    term = str(term).lower()
+    s = Session()
+    pq = []
+
+    for obj in s.query(class_):
+        counter = 0
+        for attr in vars(obj):
+            if attr.startswith('_'):
+                continue
+            if term in str(getattr(obj, attr)).lower():
+                counter += 1
+        heappush(pq, (-counter, obj, counter))
+
+    ret = []
+    for _ in range(len(pq)):
+        consider = heappop(pq)
+        if consider[2] <= 0:
+            break
+        ret.append(consider[1])
+
+    return ret

--- a/backend/models.py
+++ b/backend/models.py
@@ -279,8 +279,10 @@ def search(class_, term):
         for attr in vars(obj):
             if attr.startswith('_'):
                 continue
-            if term in str(getattr(obj, attr)).lower():
+            val = str(getattr(obj, attr)).lower()
+            while term in val:
                 counter += 1
+                val = val.replace(term, '')
         heappush(pq, (-counter, obj, counter))
 
     ret = []

--- a/backend/rest.py
+++ b/backend/rest.py
@@ -3,7 +3,7 @@ from flask_restplus import Api, Resource, reqparse, abort
 from werkzeug.contrib.fixers import ProxyFix
 from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy_searchable import search
+from sqlalchemy_searchable import search as searchable_search
 from werkzeug.exceptions import BadRequest, NotFound
 from models import *
 import about_stats
@@ -252,8 +252,13 @@ class Antenna_Res(Resource):
 class Search_Res(Resource):
 
     def get(self, term):
-        return [serialize(k) for k in search(Session().query(RLObtainable), term, sort=True)]
+        return [serialize(k) for k in search(RLObject, term)]
 
+@api.route('/searchable_search/<string:term>')
+class Searchable_Res(Resource):
+
+    def get(self, term):
+        return [serialize(k) for k in searchable_search(Session().query(RLObtainable), term, sort=True)]
 
 ### Meta mappings
 


### PR DESCRIPTION
The old search function is available at searchable_search (in case something doesn't work). The results are in the same format, but now every field is checked. This uses "contains", so any substring will match against fields; I would suggest requiring terms be 4 characters long or something.