### PR TITLE
Changed a long list of endpoints to a dictionary and factory

### DIFF
--- a/backend/rest.py
+++ b/backend/rest.py
@@ -40,6 +40,7 @@ class ID_Res(Resource):
         finally:
             s.close()
 
+
 def get_obj_by_name(Class, name):
     s = Session()
     try:        
@@ -49,6 +50,7 @@ def get_obj_by_name(Class, name):
         return serialize(query)
     finally:
         s.close()
+
 def get_obj_by_id(Class, id):
     s = Session()
     try:
@@ -58,6 +60,7 @@ def get_obj_by_id(Class, id):
         return serialize(query)
     finally:
         s.close()
+
 def get_obj_list(Class):
     s = Session()
     try:
@@ -65,201 +68,50 @@ def get_obj_list(Class):
     finally:
         s.close()
 
-### Player lookup by id number
 
-@api.route('/players/')
-class Players_Res(Resource):
-    def get(self):
-        return get_obj_list(Player)
+### Get type by name
 
-
-@api.route('/players/<string:name>')
-class Player_Res(Resource):
+# This and the other factories dynamically generate resource classes
+# for each type of endpoint. c_name must name a type from models.
+# Since using the type() constructor doesn't add the type to globals,
+# it's fine to have multiple classes with the same name.
+def SingularResourceFactory(c_name):
     def get(self, name):
         if name.isdigit():
-            return get_obj_by_id(Player, int(name))
-        return get_obj_by_name(Player, name)
+            return get_obj_by_id(globals()[c_name], int(name))
+        return get_obj_by_name(globals()[c_name], name)
+    newres = type(c_name, (Resource,), {'get': get})
+    return newres
 
-### DLC Lookup by name
-@api.route('/dlcs/')
-class DLCs_Res(Resource):
+
+### Get all of a type
+
+def MultipleResourceFactory(c_name):
     def get(self):
-        return get_obj_list(DLC)
+        return get_obj_list(globals()[c_name])
+    newres = type(c_name, (Resource,), {'get': get})
+    return newres
 
+query_pairings = {
+    'Paint': 'paints',
+    'Body': 'bodies',
+    'Decal': 'decals',
+    'Boost': 'boosts',
+    'Topper': 'toppers',
+    'Antenna': 'antennas',
+    'Trail': 'trails',
+    'Banner': 'banners',
+    'Explosion': 'explosions',
+    'Crate': 'crates',
+    'Wheel': 'wheels',
+    'DLC': 'dlcs',
+    'Player': 'players'
+}
 
-@api.route('/dlcs/<string:name>')
-class DLC_Res(Resource):
+for res, end in query_pairings.items():
+    api.add_resource(SingularResourceFactory(res), '/{0}/<string:name>'.format(end))
+    api.add_resource(MultipleResourceFactory(res), '/{0}/'.format(end))
 
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(DLC, int(name))
-        return get_obj_by_name(DLC, name)
-
-
-### Body lookup by name
-
-@api.route('/bodies/')
-class Bodies_Res(Resource):
-    def get(self):
-        return get_obj_list(Body)
-
-
-@api.route('/bodies/<string:name>')
-class Body_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Body, int(name))
-        return get_obj_by_name(Body, name)
-
-
-### Crate lookup by name
-
-@api.route('/crates/')
-class Crates_Res(Resource):
-    def get(self):
-        return get_obj_list(Crate)
-
-@api.route('/crates/<string:name>')
-class Crate_Res(Resource):
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Crate, int(name))
-        return get_obj_by_name(Crate, name)
-
-
-### Antenna lookup by name
-
-@api.route('/paints/')
-class Paints_Res(Resource):
-    def get(self):
-        return get_obj_list(Paint)
-
-@api.route('/paints/<string:name>')
-class Paint_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Paint, int(name))
-        return get_obj_by_name(Paint, name)
-
-
-### Decal lookup by name
-
-
-@api.route('/decals/')
-class Decals_Res(Resource):
-    def get(self):
-        return get_obj_list(Decal)
-
-
-@api.route('/decals/<string:name>')
-class Decal_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Decal, int(name))
-        return get_obj_by_name(Decal, name)
-
-@api.route('/boosts/')
-class Boosts_Res(Resource):
-    def get(self):
-        return get_obj_list(Boost)
-
-
-@api.route('/boosts/<string:name>')
-class Boost_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Boost, int(name))
-        return get_obj_by_name(Boost, name)
-
-
-@api.route('/wheels/')
-class Wheels_Res(Resource):
-    def get(self):
-        return get_obj_list(Wheel)
-
-
-@api.route('/wheels/<string:name>')
-class Wheel_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Wheel, int(name))
-        return get_obj_by_name(Wheel, name)
-
-
-@api.route('/toppers/')
-class Boosts_Res(Resource):
-    def get(self):
-        return get_obj_list(Topper)
-
-
-@api.route('/toppers/<string:name>')
-class Boost_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Topper, int(name))
-        return get_obj_by_name(Topper, name)
-
-@api.route('/explosions/')
-class Explosions_Res(Resource):
-    def get(self):
-        return get_obj_list(Explosion)
-
-
-@api.route('/explosions/<string:name>')
-class Explosion_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Explosion, int(name))
-        return get_obj_by_name(Explosion, name)
-
-@api.route('/trails/')
-class Trails_Res(Resource):
-    def get(self):
-        return get_obj_list(Trail)
-
-
-@api.route('/trails/<string:name>')
-class Trail_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Trail, int(name))
-        return get_obj_by_name(Trail, name)
-
-@api.route('/banners/')
-class Banners_Res(Resource):
-    def get(self):
-        return get_obj_list(Banner)
-
-
-@api.route('/banners/<string:name>')
-class Banner_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Banner, int(name))
-        return get_obj_by_name(Banner, name)
-
-@api.route('/antennas/')
-class Antennas_Res(Resource):
-    def get(self):
-        return get_obj_list(Antenna)
-
-
-@api.route('/antennas/<string:name>')
-class Antenna_Res(Resource):
-
-    def get(self, name):
-        if name.isdigit():
-            return get_obj_by_id(Antenna, int(name))
-        return get_obj_by_name(Antenna, name)
 
 ### Search
 
@@ -280,6 +132,7 @@ class Searchable_Res(Resource):
     def get(self, term):
         return [serialize(k) for k in searchable_search(Session().query(RLObtainable), term, sort=True)]
 
+
 ### Meta mappings
 
 def get_mapping(Class):
@@ -289,101 +142,32 @@ def get_mapping(Class):
     finally:
         s.close()
 
-@api.route('/meta/rarities')
-class GetRarities(Resource):
-
+def MetaResourceFactory(name):
     def get(self):
-        return get_mapping(Rarity)
+        return get_mapping(globals()[name])
+    newres = type(name, (Resource,), {'get': get})
+    return newres
 
+meta_pairings = {
+    'Rarity': 'rarities',
+    'Source': 'sources',
+    'Platform': 'platforms',
+    'Paint': 'paints',
+    'Body': 'bodies',
+    'Decal': 'decals',
+    'Boost': 'boosts',
+    'Topper': 'toppers',
+    'Antenna': 'antennas',
+    'Trail': 'trails',
+    'Banner': 'banners',
+    'Explosion': 'explosions',
+    'Crate': 'crates',
+    'Wheel': 'wheels',
+    'DLC': 'dlcs'
+}
 
-@api.route('/meta/sources')
-class GetSources(Resource):
-
-    def get(self):
-        return get_mapping(Source)
-
-
-@api.route('/meta/platforms')
-class GetPlatforms(Resource):
-
-    def get(self):
-        return get_mapping(Platform)
-
-
-@api.route('/meta/paints')
-class GetPaints(Resource):
-
-    def get(self):
-        return get_mapping(Paint)
-
-
-@api.route('/meta/bodies')
-class GetBodies(Resource):
-
-    def get(self):
-        return get_mapping(Body)
-
-
-@api.route('/meta/decals')
-class GetDecals(Resource):
-
-    def get(self):
-        return get_mapping(Decal)
-
-@api.route('/meta/boosts')
-class GetBoosts(Resource):
-
-    def get(self):
-        return get_mapping(Boost)
-
-@api.route('/meta/toppers')
-class GetToppers(Resource):
-
-    def get(self):
-        return get_mapping(Topper)
-
-@api.route('/meta/antennas')
-class GetAntennas(Resource):
-
-    def get(self):
-        return get_mapping(Antenna)
-
-@api.route('/meta/trails')
-class GetBoosts(Resource):
-
-    def get(self):
-        return get_mapping(Trail)
-
-@api.route('/meta/banners')
-class GetBanners(Resource):
-
-    def get(self):
-        return get_mapping(Banner)
-
-@api.route('/meta/explosions')
-class GetExplosions(Resource):
-
-    def get(self):
-        return get_mapping(Explosion)
-
-
-@api.route('/meta/crates')
-class GetCrates(Resource):
-
-    def get(self):
-        return get_mapping(Crate)
-    
-@api.route('/meta/wheels')
-class GetWheels(Resource):
-
-    def get(self):
-        return get_mapping(Wheel)
-
-@api.route('/meta/dlcs')
-class GetDLCs(Resource):
-
-    def get(self):
-        return get_mapping(DLC)
+for res, end in meta_pairings.items():
+    api.add_resource(MetaResourceFactory(res), '/meta/{0}'.format(end))
 
 
 @api.route('/meta/about')


### PR DESCRIPTION
So instead of a ton of "class X(Resource): def get(): ..." for each type, I wrote a factory that dynamically creates resource classes. From the outside nothing has changed, but this halves the number of lines in rest.py. It makes the code cleaner, but probably less readable, so up to yall if it gets incorporated.